### PR TITLE
Add Dockerization of gnosis script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,38 @@
+name: deploy
+
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          labels: |
+            org.opencontainers.image.licenses=MIT OR Apache-2.0
+
+      - name: Push Reward Script Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . .
+
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["python", "-m", "src.main_script"]

--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ There is also an optional argument that can be passed, which removes the transfe
 python -m src.main_script 2024 4 9 ignore_gnosis_transfers
 ```
 
+
+The script can also be run by building and running the Dockerfile:
+
+```
+docker build -t payoutsscript .
+docker run --rm -v $(pwd)/out:/app/out payoutsscript 2025 4 8 ignore_gnosis_transfers
+```


### PR DESCRIPTION
This PR adds a Dockerfile to the project repository that is built and pushed to GHCR when the main branch is updated. This allows the script to be run as a docker container rather than cloning the repository and running it locally, making it easier to run the script.